### PR TITLE
Fix pagination url so it uses api gateway

### DIFF
--- a/configuration-example.yaml
+++ b/configuration-example.yaml
@@ -47,3 +47,4 @@ locations:
   esUrl: http://elastic-search-url.example.com
   esIndex: elastic-search-index
   estype: elastic-search-type
+  gatewayUrl: https://api.example.com

--- a/src/main/groovy/edu/oregonstate/mist/locations/frontend/db/LocationDAO.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/locations/frontend/db/LocationDAO.groovy
@@ -52,6 +52,10 @@ class LocationDAO {
         }
     }
 
+    String getGatewayUrl() {
+        locationConfiguration.get("gatewayUrl")
+    }
+
     /**
      * Returns url of elastic search collection and type to search.
      *

--- a/src/main/groovy/edu/oregonstate/mist/locations/frontend/jsonapi/ResourceObject.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/locations/frontend/jsonapi/ResourceObject.groovy
@@ -4,4 +4,5 @@ class ResourceObject {
     String id
     String type
     def attributes
+    def links
 }

--- a/src/main/groovy/edu/oregonstate/mist/locations/frontend/resources/LocationResource.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/locations/frontend/resources/LocationResource.groovy
@@ -165,7 +165,7 @@ class LocationResource extends Resource {
      * @return
      */
     private String getPaginationUrl(def params) {
-        def uriAndPath = uriInfo.getBaseUri().toString() + uriInfo.getPath()
+        def uriAndPath = locationDAO.getGatewayUrl() + uriInfo.getPath()
         def nonNullParams = params.clone()
         // convert pageVariable to page[variable]
         nonNullParams["page[number]"] = nonNullParams['pageNumber']

--- a/src/main/groovy/edu/oregonstate/mist/locations/frontend/resources/LocationResource.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/locations/frontend/resources/LocationResource.groovy
@@ -94,13 +94,8 @@ class LocationResource extends Resource {
 
         def topLevelHits = actualObj.get("hits")
         topLevelHits.get("hits").asList().each {
-            def source = it.get("_source")
-            ResourceObject resourceObject = new ResourceObject(
-                    id: source.get("id").asText(),
-                    type: source.get("type").asText(),
-                    attributes: source.get("attributes")
-            )
-            resultObject.data += resourceObject
+            String singleLocation = it.get("_source").toString()
+            resultObject.data += (ResourceObject) mapper.readValue(singleLocation, Object.class)
         }
 
         setPaginationLinks(topLevelHits, q, type, campus, resultObject)


### PR DESCRIPTION
CO-348

The pagination urls were using the DW endpoints. They need to return
the api gateway url instead. Since the DW code is not aware of the
proxy / gateway in place, I added a property for this.
