### PR TITLE
Add diff processing for buildings w/ same name but different old/new IDs

### DIFF
--- a/DataDiscrepancyUtil/README.md
+++ b/DataDiscrepancyUtil/README.md
@@ -6,6 +6,8 @@ It'll report any locations that no longer exist in the new data. (Peavy Hall, wh
 
 It'll report locations that recieved a new key (rekeyed in Elastic Search) but still exists in the new data set. (Johnson Hall is an example of this)
 
+The buildings that have both an old and new key will be outputed to a json file called [buildingsWithOldNewKeys.json](buildingsWithOldNewKeys.json).
+
 Finally it'll report any new locations that weren't in the old data at all. (Tykeson Hall is an example of this)
 
 ## Invocation

--- a/DataDiscrepancyUtil/dataDiffCheck.py
+++ b/DataDiscrepancyUtil/dataDiffCheck.py
@@ -20,16 +20,39 @@ if __name__ == "__main__":
         new_building_data_dict = {}
         old_building_data_dict = {}
 
-        #Create a dict of the new building data to make the next loop simpler
+        # TODO Rename this name view dict
+        # This is for the NAME : {OLD, NEW} stuff
+        new_bdata_name_dict = {}
+        old_bdata_name_dict = {}
         for new_building in new_building_data_json['data']:
             new_building_data_dict[new_building['id']] = new_building
 
         for old_building in old_building_data_json['data']:
             old_building_data_dict[old_building['id']] = old_building
+            old_bdata_name_dict[old_building['attributes']
+                                ['name']] = old_building['id']
 
         old_bdict_view = old_building_data_dict.viewkeys()
         new_bdict_view = new_building_data_dict.viewkeys()
-        
+
+        # NAME : {OLD, NEW} Processing
+        new_bdata_name_view = new_bdata_name_dict.viewkeys()
+        old_bdata_name_view = old_bdata_name_dict.viewkeys()
+        building_key_intersection = old_bdata_name_view & new_bdata_name_view
+
+        bkey_intersection_dict = {}
+
+        for k in building_key_intersection:
+            bkey_intersection_dict[k] = {
+                "old": old_bdata_name_dict[k],
+                "new": new_bdata_name_dict[k]
+            }
+        # TODO Add -o output filename option for (OLD,NEW) keyed building json file
+        print "\n Outputing buildings with new and old keys to buildingsWithOldNewKeys.json\n"
+        with open("buildingsWithOldNewKeys.json", "w") as intersection_file:
+            intersection_file.write(json.dumps(
+                {"buildings": bkey_intersection_dict}))
+        # Report Processing
         rekeyCheckDict = {}
         rekeyedBuildings = []
         totallyNewBuildings = []

--- a/DataDiscrepancyUtil/dataDiffCheck.py
+++ b/DataDiscrepancyUtil/dataDiffCheck.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
         print "\n Outputing buildings with new and old keys to buildingsWithOldNewKeys.json\n"
         with open("buildingsWithOldNewKeys.json", "w") as intersection_file:
             intersection_file.write(json.dumps(
-                {"buildings": bkey_intersection_dict}))
+                {"buildings": bkey_intersection_dict},indent=4, sort_keys=True))
         # Report Processing
         rekeyCheckDict = {}
         rekeyedBuildings = []

--- a/DataDiscrepancyUtil/dataDiffCheck.py
+++ b/DataDiscrepancyUtil/dataDiffCheck.py
@@ -3,8 +3,8 @@ import json
 
 if __name__ == "__main__":
     print("Expecting old.json and new.json as input files 1 and 2.")
-    #old.json being the data from https://api.oregonstate.edu/v1/locations?page[size]=10000&type=building
-    #new.json being the data from https://localhost:8082/api/v0/locations?page[size]=10000&type=building - locations-frontend-api commit b1bec1e013cf29f16a0a01b9dd7c3777e3b4e192
+    # old.json being the data from https://api.oregonstate.edu/v1/locations?page[size]=10000&type=building
+    # new.json being the data from https://localhost:8082/api/v0/locations?page[size]=10000&type=building - locations-frontend-api commit b1bec1e013cf29f16a0a01b9dd7c3777e3b4e192
 
     if(len(sys.argv) >= 3):
         if(sys.argv[1] == sys.argv[2]):
@@ -12,9 +12,9 @@ if __name__ == "__main__":
         print sys.argv[1] + " as old_file"
         print sys.argv[2] + " as new_file"
 
-        with open(sys.argv[1],"r") as old_file:
+        with open(sys.argv[1], "r") as old_file:
             old_building_data_json = json.loads(old_file.read())
-        with open(sys.argv[2],"r") as new_file:
+        with open(sys.argv[2], "r") as new_file:
             new_building_data_json = json.loads(new_file.read())
 
         new_building_data_dict = {}
@@ -24,8 +24,12 @@ if __name__ == "__main__":
         # This is for the NAME : {OLD, NEW} stuff
         new_bdata_name_dict = {}
         old_bdata_name_dict = {}
+
+        # Create a dict of the new building data to make the next loop simpler
         for new_building in new_building_data_json['data']:
             new_building_data_dict[new_building['id']] = new_building
+            new_bdata_name_dict[new_building['attributes']
+                                ['name']] = new_building['id']
 
         for old_building in old_building_data_json['data']:
             old_building_data_dict[old_building['id']] = old_building
@@ -57,13 +61,17 @@ if __name__ == "__main__":
         rekeyedBuildings = []
         totallyNewBuildings = []
 
-        if (old_bdict_view ^ new_bdict_view) != set([]): #Dictionary View symetric diff returns set([]) when theres no difference
-            #There are differences
-            print "\nThese are the keys from the older data that is no longer present in the new data\n"
+        # Dictionary View symetric diff returns set([]) when theres no difference
+        if (old_bdict_view ^ new_bdict_view) != set([]):
+            # There are differences
+            print "\nThese are old ID keys (from the older data) that are no longer present in the new data\n"
             gone_old_buildings = list(old_bdict_view - new_bdict_view)
+
             for gone_b in gone_old_buildings:
                 print gone_b + "  ---  " + old_building_data_dict[gone_b]['attributes']['name']
-                rekeyCheckDict[ old_building_data_dict[gone_b]['attributes']['name'] ] = gone_b
+                rekeyCheckDict[old_building_data_dict[gone_b]
+                               ['attributes']['name']] = gone_b
+
             print "\nThese are new location keys that didn't exist in the old data\n"
 
             gone_new_buildings = list(new_bdict_view - old_bdict_view)
@@ -72,11 +80,15 @@ if __name__ == "__main__":
                 if rekeyCheckDict.has_key(bname):
                     print gone_b + "  --- REKEYED! ---  " + new_building_data_dict[gone_b]['attributes']['name']
                     rekeyedBuildings.append(gone_b)
+                    # TODO put all the rekeyed buildings into array https://jira.sig.oregonstate.edu/browse/CO-932
                 else:
                     totallyNewBuildings.append(gone_b)
+
             print "\nThese are the totally new buildings\n"
             for gone_b in totallyNewBuildings:
-                print gone_b + "  ---  " + new_building_data_dict[gone_b]['attributes']['name'] 
-            #print new_bdict_view - old_bdict_view
+                print gone_b + "  ---  " + new_building_data_dict[gone_b]['attributes']['name']
+            # print new_bdict_view - old_bdict_view
         else:
             print "There are no differences."
+
+# TODO sort output


### PR DESCRIPTION
CO-932

This PR adds reporting for buildings that exist in both data sets but have rekeyed. Currently it outputs it in this json format to a file named buildingsWithOldNewKeys.json

```json
{
  "building": {
    "Arnold Dining Center": {
      "old": "OLDID",
      "new": "NEWID"
    }
}
```

Current issues: The Food 2 You key shows up like this ""Food 2 You <em><a href=\"//uhds.link/food2you\" style=\"text-decoration: inherit;\n    color: blue;\">(View Menu / Order)</a></em>""