### PR TITLE
Remove Polygon test

### DIFF
--- a/src/test/integration/integrationtests.py
+++ b/src/test/integration/integrationtests.py
@@ -226,8 +226,7 @@ class gateway_tests(unittest.TestCase):
     # Test GeoJSON result only contains Polygon or Point
     def test_geojson_geometry(self):
         geometry_list = {
-            'dd90d825dc2f8b5bb5b72b3d41a46d87': type(geojson.Point()),   # Point
-            '937eada7c23344d68d0d6fc5ce906cdf': type(geojson.Polygon())  # Polygon
+            'dd90d825dc2f8b5bb5b72b3d41a46d87': type(geojson.Point()),  # Point
         }
 
         for resource_id in geometry_list.keys():


### PR DESCRIPTION
Since we've already had a [test case](https://github.com/osu-mist/locations-frontend-api/blob/develop/src/test/integration/integrationtests.py#L204) for geometryCollection, I just simply deleted the problematic location here as a fix.