### PR TITLE
only get parking locations

### DIFF
--- a/src/test/integration/integrationtests.py
+++ b/src/test/integration/integrationtests.py
@@ -349,7 +349,8 @@ class gateway_tests(unittest.TestCase):
         payload = {
             'adaParkingSpaceCount': randint(0, 5),
             'motorcycleParkingSpaceCount': randint(0, 5),
-            'evParkingSpaceCount': randint(0, 5)
+            'evParkingSpaceCount': randint(0, 5),
+            'type': 'parking'
         }
 
         all_parkings = query_request(locations_url, access_token, 'get',


### PR DESCRIPTION
if the random number generated was 0, it would also return locations with null counts for moto/ev/ada spaces. This would cause the test to throw an error when comparing a number to null. All parking locations should have a number for the ev/ada/moto fields, so getting only parking data tests that these fields are never null.